### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/abortaction.retry.py
+++ b/examples/abortaction.retry.py
@@ -11,4 +11,4 @@ from prompt_toolkit import prompt, AbortAction
 
 if __name__ == '__main__':
     answer = prompt('Give me some input: ', on_abort=AbortAction.RETRY)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/auto-suggestion.py
+++ b/examples/auto-suggestion.py
@@ -33,7 +33,7 @@ def main():
                   auto_suggest=AutoSuggestFromHistory(),
                   enable_history_search=True,
                   on_abort=AbortAction.RETRY)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/autocompletion.py
+++ b/examples/autocompletion.py
@@ -52,7 +52,7 @@ animal_completer = WordCompleter([
 def main():
     text = prompt('Give some animals: ', completer=animal_completer,
                   complete_while_typing=False)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/autocorrection.py
+++ b/examples/autocorrection.py
@@ -39,7 +39,7 @@ def main():
 
     # Read input.
     text = prompt('Say something: ', key_bindings_registry=key_bindings_manager.registry)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/bottom-toolbar.py
+++ b/examples/bottom-toolbar.py
@@ -20,7 +20,7 @@ def main():
     text = prompt('Say something: ',
                   get_bottom_toolbar_tokens=get_bottom_toolbar_tokens,
                   style=test_style)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/clock-input.py
+++ b/examples/clock-input.py
@@ -20,7 +20,7 @@ def _clock_tokens(cli):
     " Tokens to be shown before the prompt. "
     now = datetime.datetime.now()
     return [
-        (Token.Prompt, '%s:%s:%s' % (now.hour, now.minute, now.second)),
+        (Token.Prompt, '{0!s}:{1!s}:{2!s}'.format(now.hour, now.minute, now.second)),
         (Token.Prompt, ' Enter something: ')
     ]
 
@@ -56,7 +56,7 @@ def main():
     cli = CommandLineInterface(application=app, eventloop=eventloop)
 
     code_obj = cli.run()
-    print('You said: %s' % code_obj.text)
+    print('You said: {0!s}'.format(code_obj.text))
 
     eventloop.close()
 

--- a/examples/colored-prompt.py
+++ b/examples/colored-prompt.py
@@ -40,4 +40,4 @@ def get_prompt_tokens(cli):
 
 if __name__ == '__main__':
     answer = prompt(get_prompt_tokens=get_prompt_tokens, style=example_style)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/custom-key-binding.py
+++ b/examples/custom-key-binding.py
@@ -50,7 +50,7 @@ def main():
     # Read input.
     print('Press F4 to insert "hello world", type "xy" to insert "z":')
     text = prompt('> ', key_bindings_registry=key_bindings_manager.registry)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/get-input-vi-mode.py
+++ b/examples/get-input-vi-mode.py
@@ -6,4 +6,4 @@ from prompt_toolkit import prompt
 if __name__ == '__main__':
     print("You have Vi keybindings here. Press [Esc] to go to navigation mode.")
     answer = prompt('Give me some input: ', multiline=False, vi_mode=True)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/get-input-with-default.py
+++ b/examples/get-input-with-default.py
@@ -8,5 +8,5 @@ from prompt_toolkit import prompt
 import getpass
 
 if __name__ == '__main__':
-    answer = prompt('What is your name: ', default='%s' % getpass.getuser())
-    print('You said: %s' % answer)
+    answer = prompt('What is your name: ', default='{0!s}'.format(getpass.getuser()))
+    print('You said: {0!s}'.format(answer))

--- a/examples/get-input.py
+++ b/examples/get-input.py
@@ -5,4 +5,4 @@ from prompt_toolkit import prompt
 
 if __name__ == '__main__':
     answer = prompt('Give me some input: ')
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/get-multiline-input.py
+++ b/examples/get-multiline-input.py
@@ -16,4 +16,4 @@ if __name__ == '__main__':
     print('Press [Meta+Enter] or [Esc] followed by [Enter] to accept input.')
     answer = prompt('Multiline input: ', multiline=True,
                     get_continuation_tokens=continuation_tokens)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/get-password-with-toggle-display-shortcut.py
+++ b/examples/get-password-with-toggle-display-shortcut.py
@@ -24,7 +24,7 @@ def main():
     password = prompt('Password: ',
                       is_password=Condition(lambda cli: hidden[0]),
                       key_bindings_registry=key_bindings_manager.registry)
-    print('You said: %s' % password)
+    print('You said: {0!s}'.format(password))
 
 
 if __name__ == '__main__':

--- a/examples/get-password.py
+++ b/examples/get-password.py
@@ -5,4 +5,4 @@ from prompt_toolkit import prompt
 
 if __name__ == '__main__':
     password = prompt('Password: ', is_password=True)
-    print('You said: %s' % password)
+    print('You said: {0!s}'.format(password))

--- a/examples/html-input.py
+++ b/examples/html-input.py
@@ -11,7 +11,7 @@ from prompt_toolkit.layout.lexers import PygmentsLexer
 
 def main():
     text = prompt('Enter HTML: ', lexer=PygmentsLexer(HtmlLexer))
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/input-validation.py
+++ b/examples/input-validation.py
@@ -17,7 +17,7 @@ class EmailValidator(Validator):
 
 def main():
     text = prompt('Enter e-mail address: ', validator=EmailValidator())
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 if __name__ == '__main__':
     main()

--- a/examples/inputhook.py
+++ b/examples/inputhook.py
@@ -73,7 +73,7 @@ def main():
                     eventloop=create_eventloop(inputhook=inputhook),
                     lexer=PythonLexer,
                     patch_stdout=True)
-    print('You said: %s' % result)
+    print('You said: {0!s}'.format(result))
 
 
 if __name__ == '__main__':

--- a/examples/mouse-support.py
+++ b/examples/mouse-support.py
@@ -7,4 +7,4 @@ if __name__ == '__main__':
     print('This is multiline input. press [Meta+Enter] or [Esc] followed by [Enter] to accept input.')
     print('You can click with the mouse in order to select text.')
     answer = prompt('Multiline input: ', multiline=True, mouse_support=True)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/multi-column-autocompletion-with-meta.py
+++ b/examples/multi-column-autocompletion-with-meta.py
@@ -27,7 +27,7 @@ animal_completer = WordCompleter([
 
 def main():
     text = prompt('Give some animals: ', completer=animal_completer, display_completions_in_columns=True)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/multi-column-autocompletion.py
+++ b/examples/multi-column-autocompletion.py
@@ -46,7 +46,7 @@ animal_completer = WordCompleter([
 
 def main():
     text = prompt('Give some animals: ', completer=animal_completer, display_completions_in_columns=True)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/multiline-prompt.py
+++ b/examples/multiline-prompt.py
@@ -8,4 +8,4 @@ from prompt_toolkit import prompt
 
 if __name__ == '__main__':
     answer = prompt('Give me some input:\n > ', multiline=True)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/no-wrapping.py
+++ b/examples/no-wrapping.py
@@ -5,4 +5,4 @@ from prompt_toolkit import prompt
 
 if __name__ == '__main__':
     answer = prompt('Give me some input: ', wrap_lines=False, multiline=True)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/patch-stdout.py
+++ b/examples/patch-stdout.py
@@ -20,14 +20,14 @@ def main():
         i = 0
         while running:
             i += 1
-            print('i=%i' % i)
+            print('i={0:d}'.format(i))
             time.sleep(1)
     threading.Thread(target=thread).start()
 
     # Now read the input. The print statements of the other thread
     # should not disturb anything.
     result = prompt('Say something: ', patch_stdout=True)
-    print('You said: %s' % result)
+    print('You said: {0!s}'.format(result))
 
     # Stop thrad.
     running = False

--- a/examples/persistent-history.py
+++ b/examples/persistent-history.py
@@ -12,7 +12,7 @@ from prompt_toolkit.history import FileHistory
 def main():
     our_history = FileHistory('.example-history-file')
     text = prompt('Say something: ', history=our_history)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/examples/regular-language.py
+++ b/examples/regular-language.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
                 }[vars.get('operator1') or vars.get('operator2')]
 
                 # Execute and print the result.
-                print('Result: %s\n' % (operator(var1, var2)))
+                print('Result: {0!s}\n'.format((operator(var1, var2))))
 
             elif vars.get('operator2'):
                 print('Operator 2')

--- a/examples/rprompt.py
+++ b/examples/rprompt.py
@@ -26,4 +26,4 @@ def get_rprompt_tokens(cli):
 
 if __name__ == '__main__':
     answer = prompt('> ', get_rprompt_tokens=get_rprompt_tokens, style=example_style)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/switch-between-vi-emacs.py
+++ b/examples/switch-between-vi-emacs.py
@@ -34,7 +34,7 @@ def run():
         " Display the current input mode. "
         text = 'Vi' if vi_mode_enabled else 'Emacs'
         return [
-            (Token.Toolbar, ' [F4] %s ' % text)
+            (Token.Toolbar, ' [F4] {0!s} '.format(text))
         ]
 
     prompt('> ', key_bindings_registry=manager.registry,

--- a/examples/system-clipboard-integration.py
+++ b/examples/system-clipboard-integration.py
@@ -16,4 +16,4 @@ if __name__ == '__main__':
     print('')
 
     answer = prompt('Give me some input: ', clipboard=PyperclipClipboard())
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/system-prompt.py
+++ b/examples/system-prompt.py
@@ -6,4 +6,4 @@ from prompt_toolkit import prompt
 if __name__ == '__main__':
     print('If you press meta-! or esc-! at the following prompt, you can enter system commands.')
     answer = prompt('Give me some input: ', enable_system_bindings=True)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/telnet.py
+++ b/examples/telnet.py
@@ -37,7 +37,7 @@ class ExampleApplication(TelnetApplication):
         if document.text == 'exit':
             telnet_connection.close()
         else:
-            telnet_connection.send('You said: %s\n\n' % document.text)
+            telnet_connection.send('You said: {0!s}\n\n'.format(document.text))
 
     def client_leaving(self, telnet_connection):
         # Say 'bye' when the client quits.

--- a/examples/terminal-title.py
+++ b/examples/terminal-title.py
@@ -8,4 +8,4 @@ if __name__ == '__main__':
         return 'This is the title'
 
     answer = prompt('Give me some input: ', get_title=get_title)
-    print('You said: %s' % answer)
+    print('You said: {0!s}'.format(answer))

--- a/examples/up-arrow-partial-string-matching.py
+++ b/examples/up-arrow-partial-string-matching.py
@@ -29,7 +29,7 @@ def main():
     text = prompt('Say something: ', history=history,
                   enable_history_search=True,
                   on_abort=AbortAction.RETRY)
-    print('You said: %s' % text)
+    print('You said: {0!s}'.format(text))
 
 
 if __name__ == '__main__':

--- a/prompt_toolkit/auto_suggest.py
+++ b/prompt_toolkit/auto_suggest.py
@@ -30,7 +30,7 @@ class Suggestion(object):
         self.text = text
 
     def __repr__(self):
-        return 'Suggestion(%s)' % self.text
+        return 'Suggestion({0!s})'.format(self.text)
 
 
 class AutoSuggest(with_metaclass(ABCMeta, object)):

--- a/prompt_toolkit/buffer.py
+++ b/prompt_toolkit/buffer.py
@@ -108,7 +108,7 @@ class CompletionState(object):
         self.complete_index = complete_index  # Position in the `_completions` array.
 
     def __repr__(self):
-        return '%s(%r, <%r> completions, index=%r)' % (
+        return '{0!s}({1!r}, <{2!r}> completions, index={3!r})'.format(
             self.__class__.__name__,
             self.original_document, len(self.current_completions), self.complete_index)
 
@@ -314,7 +314,7 @@ class Buffer(object):
         valid for this text. text/cursor_position should be consistent at any time,
         otherwise set a Document instead.)
         """
-        assert isinstance(value, six.text_type), 'Got %r' % value
+        assert isinstance(value, six.text_type), 'Got {0!r}'.format(value)
         assert self.cursor_position <= len(value)
 
         # Don't allow editing of read-only buffers.
@@ -704,9 +704,9 @@ class Buffer(object):
 
                         # Create completion.
                         if i == self.working_index:
-                            display_meta = "Current, line %s" % (j+1)
+                            display_meta = "Current, line {0!s}".format((j+1))
                         else:
-                            display_meta = "History %s, line %s" % (i+1, j+1)
+                            display_meta = "History {0!s}, line {1!s}".format(i+1, j+1)
 
                         completions.append(Completion(
                             l,

--- a/prompt_toolkit/completion.py
+++ b/prompt_toolkit/completion.py
@@ -40,7 +40,7 @@ class Completion(object):
         assert self.start_position <= 0
 
     def __repr__(self):
-        return '%s(text=%r, start_position=%r)' % (
+        return '{0!s}(text={1!r}, start_position={2!r})'.format(
             self.__class__.__name__, self.text, self.start_position)
 
     def __eq__(self, other):
@@ -91,7 +91,7 @@ class CompleteEvent(object):
         self.completion_requested = completion_requested
 
     def __repr__(self):
-        return '%s(text_inserted=%r, completion_requested=%r)' % (
+        return '{0!s}(text_inserted={1!r}, completion_requested={2!r})'.format(
             self.__class__.__name__, self.text_inserted, self.completion_requested)
 
 

--- a/prompt_toolkit/contrib/regular_languages/regex_parser.py
+++ b/prompt_toolkit/contrib/regular_languages/regex_parser.py
@@ -53,7 +53,7 @@ class Any(Node):
         return Any(self.children + [other_node])
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.children)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.children)
 
 
 class Sequence(Node):
@@ -68,7 +68,7 @@ class Sequence(Node):
         return Sequence(self.children + [other_node])
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.children)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.children)
 
 
 class Regex(Node):
@@ -81,7 +81,7 @@ class Regex(Node):
         self.regex = regex
 
     def __repr__(self):
-        return '%s(/%s/)' % (self.__class__.__name__, self.regex)
+        return '{0!s}(/{1!s}/)'.format(self.__class__.__name__, self.regex)
 
 
 class Lookahead(Node):
@@ -93,7 +93,7 @@ class Lookahead(Node):
         self.negative = negative
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.childnode)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.childnode)
 
 
 class Variable(Node):
@@ -109,7 +109,7 @@ class Variable(Node):
         self.varname = varname
 
     def __repr__(self):
-        return '%s(childnode=%r, varname=%r)' % (
+        return '{0!s}(childnode={1!r}, varname={2!r})'.format(
             self.__class__.__name__, self.childnode, self.varname)
 
 
@@ -121,7 +121,7 @@ class Repeat(Node):
         self.greedy = greedy
 
     def __repr__(self):
-        return '%s(childnode=%r)' % (self.__class__.__name__, self.childnode)
+        return '{0!s}(childnode={1!r})'.format(self.__class__.__name__, self.childnode)
 
 
 def tokenize_regex(input):
@@ -242,10 +242,10 @@ def parse_regex(regex_tokens):
 
             elif t.startswith('{'):
                 # TODO: implement!
-                raise Exception('{}-style repitition not yet supported' % t)
+                raise Exception('{{}}-style repitition not yet supported'.format(*t))
 
             elif t.startswith('(?'):
-                raise Exception('%r not supported' % t)
+                raise Exception('{0!r} not supported'.format(t))
 
             elif t.isspace():
                 pass

--- a/prompt_toolkit/contrib/telnet/server.py
+++ b/prompt_toolkit/contrib/telnet/server.py
@@ -87,7 +87,7 @@ class _ConnectionStdout(object):
         try:
             self._connection.send(b''.join(self._buffer))
         except socket.error as e:
-            logger.error("Couldn't send data over socket: %s" % e)
+            logger.error("Couldn't send data over socket: {0!s}".format(e))
 
         self._buffer = []
 

--- a/prompt_toolkit/document.py
+++ b/prompt_toolkit/document.py
@@ -79,13 +79,13 @@ class Document(object):
     __slots__ = ('text', 'cursor_position', 'selection', '_cache')
 
     def __init__(self, text='', cursor_position=None, selection=None):
-        assert isinstance(text, six.text_type), 'Got %r' % text
+        assert isinstance(text, six.text_type), 'Got {0!r}'.format(text)
         assert selection is None or isinstance(selection, SelectionState)
 
         # Check cursor position. It can also be right after the end. (Where we
         # insert text.)
         assert cursor_position is None or cursor_position <= len(text), AssertionError(
-                'cursor_position=%r, len_text=%r' % (cursor_position, len(text)))
+                'cursor_position={0!r}, len_text={1!r}'.format(cursor_position, len(text)))
 
         # By default, if no cursor position was given, make sure to put the
         # cursor position is at the end of the document. This is what makes
@@ -102,7 +102,7 @@ class Document(object):
         self._cache = _text_to_document_cache.setdefault(self.text, _DocumentCache())
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self.text, self.cursor_position)
+        return '{0!s}({1!r}, {2!r})'.format(self.__class__.__name__, self.text, self.cursor_position)
 
     @property
     def current_char(self):

--- a/prompt_toolkit/filters/base.py
+++ b/prompt_toolkit/filters/base.py
@@ -34,7 +34,7 @@ class Filter(with_metaclass(ABCMeta, object)):
         elif isinstance(other, Never) or isinstance(self, Always):
             return other
         else:
-            assert isinstance(other, Filter), 'Expecting filter, got %r' % other
+            assert isinstance(other, Filter), 'Expecting filter, got {0!r}'.format(other)
             return _and(self, other)
 
     def __or__(self, other):
@@ -46,7 +46,7 @@ class Filter(with_metaclass(ABCMeta, object)):
         elif isinstance(other, Never) or isinstance(self, Always):
             return self
         else:
-            assert isinstance(other, Filter), 'Expecting filter, got %r' % other
+            assert isinstance(other, Filter), 'Expecting filter, got {0!r}'.format(other)
             return _or(self, other)
 
     def __invert__(self):
@@ -178,7 +178,7 @@ class _Invert(Filter):
         return not self.filter(*a, **kw)
 
     def __repr__(self):
-        return '~%r' % self.filter
+        return '~{0!r}'.format(self.filter)
 
     def test_args(self, *args):
         return self.filter.test_args(*args)
@@ -229,7 +229,7 @@ class Condition(Filter):
         return self.func(*a, **kw)
 
     def __repr__(self):
-        return 'Condition(%r)' % self.func
+        return 'Condition({0!r})'.format(self.func)
 
     def test_args(self, *a):
         return test_callable_args(self.func, a)

--- a/prompt_toolkit/filters/cli.py
+++ b/prompt_toolkit/filters/cli.py
@@ -32,7 +32,7 @@ class HasFocus(Filter):
         return cli.current_buffer_name == self.buffer_name
 
     def __repr__(self):
-        return 'HasFocus(%r)' % self.buffer_name
+        return 'HasFocus({0!r})'.format(self.buffer_name)
 
 
 class InFocusStack(Filter):
@@ -46,7 +46,7 @@ class InFocusStack(Filter):
         return self.buffer_name in cli.buffers.focus_stack
 
     def __repr__(self):
-        return 'InFocusStack(%r)' % self.buffer_name
+        return 'InFocusStack({0!r})'.format(self.buffer_name)
 
 
 class HasSelection(Filter):

--- a/prompt_toolkit/filters/utils.py
+++ b/prompt_toolkit/filters/utils.py
@@ -17,7 +17,7 @@ def to_simple_filter(bool_or_filter):
     turn it into a SimpleFilter.
     """
     if not isinstance(bool_or_filter, (bool, SimpleFilter)):
-        raise TypeError('Expecting a bool or a SimpleFilter instance. Got %r' % bool_or_filter)
+        raise TypeError('Expecting a bool or a SimpleFilter instance. Got {0!r}'.format(bool_or_filter))
 
     return {
         True: _always,
@@ -31,7 +31,7 @@ def to_cli_filter(bool_or_filter):
     turn it into a CLIFilter.
     """
     if not isinstance(bool_or_filter, (bool, CLIFilter)):
-        raise TypeError('Expecting a bool or a CLIFilter instance. Got %r' % bool_or_filter)
+        raise TypeError('Expecting a bool or a CLIFilter instance. Got {0!r}'.format(bool_or_filter))
 
     return {
         True: _always,

--- a/prompt_toolkit/history.py
+++ b/prompt_toolkit/history.py
@@ -106,9 +106,9 @@ class FileHistory(History):
             def write(t):
                 f.write(t.encode('utf-8'))
 
-            write('\n# %s\n' % datetime.datetime.now())
+            write('\n# {0!s}\n'.format(datetime.datetime.now()))
             for line in string.split('\n'):
-                write('+%s\n' % line)
+                write('+{0!s}\n'.format(line))
 
     def __getitem__(self, key):
         return self.strings[key]

--- a/prompt_toolkit/input.py
+++ b/prompt_toolkit/input.py
@@ -63,7 +63,7 @@ class StdinInput(Input):
         self.stdin = stdin or sys.stdin
 
     def __repr__(self):
-        return 'StdinInput(stdin=%r)' % (self.stdin,)
+        return 'StdinInput(stdin={0!r})'.format(self.stdin)
 
     def raw_mode(self):
         return raw_mode(self.stdin.fileno())

--- a/prompt_toolkit/key_binding/input_processor.py
+++ b/prompt_toolkit/key_binding/input_processor.py
@@ -29,7 +29,7 @@ class KeyPress(object):
         self.data = data
 
     def __repr__(self):
-        return '%s(key=%r, data=%r)' % (
+        return '{0!s}(key={1!r}, data={2!r})'.format(
             self.__class__.__name__, self.key, self.data)
 
     def __eq__(self, other):
@@ -223,7 +223,7 @@ class Event(object):
         self._arg = arg
 
     def __repr__(self):
-        return 'Event(arg=%r, key_sequence=%r, is_repeat=%r)' % (
+        return 'Event(arg={0!r}, key_sequence={1!r}, is_repeat={2!r})'.format(
                 self.arg, self.key_sequence, self.is_repeat)
 
     @property
@@ -269,7 +269,7 @@ class Event(object):
                 data = '-1'
             result = int(data)
         else:
-            result = int("%s%s" % (current, data))
+            result = int("{0!s}{1!s}".format(current, data))
 
         # Don't exceed a million.
         if int(result) >= 1000000:

--- a/prompt_toolkit/key_binding/registry.py
+++ b/prompt_toolkit/key_binding/registry.py
@@ -33,7 +33,7 @@ class _Binding(object):
         return self.handler(event)
 
     def __repr__(self):
-        return '%s(keys=%r, handler=%r)' % (
+        return '{0!s}(keys={1!r}, handler={2!r})'.format(
             self.__class__.__name__, self.keys, self.handler)
 
 
@@ -124,7 +124,7 @@ class Registry(object):
                 return
 
         # No key binding found for this function. Raise ValueError.
-        raise ValueError('Binding not found: %r' % (function, ))
+        raise ValueError('Binding not found: {0!r}'.format(function ))
 
     def get_bindings_for_keys(self, keys):
         """

--- a/prompt_toolkit/keys.py
+++ b/prompt_toolkit/keys.py
@@ -14,7 +14,7 @@ class Key(object):
         self.name = name
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.name)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.name)
 
 
 class Keys(object):

--- a/prompt_toolkit/layout/containers.py
+++ b/prompt_toolkit/layout/containers.py
@@ -586,7 +586,7 @@ class Float(object):
             return self._get_height(cli)
 
     def __repr__(self):
-        return 'Float(content=%r)' % self.content
+        return 'Float(content={0!r})'.format(self.content)
 
 
 class WindowRenderInfo(object):
@@ -823,7 +823,7 @@ class ScrollOffsets(object):
         return int(self._right)
 
     def __repr__(self):
-        return 'ScrollOffsets(top=%r, bottom=%r, left=%r, right=%r)' % (
+        return 'ScrollOffsets(top={0!r}, bottom={1!r}, left={2!r}, right={3!r})'.format(
             self.top, self.bottom, self.left, self.right)
 
 
@@ -908,7 +908,7 @@ class Window(Container):
         self.reset()
 
     def __repr__(self):
-        return 'Window(content=%r)' % self.content
+        return 'Window(content={0!r})'.format(self.content)
 
     def reset(self):
         self.content.reset()
@@ -1499,7 +1499,7 @@ class ConditionalContainer(Container):
         self.filter = to_cli_filter(filter)
 
     def __repr__(self):
-        return 'ConditionalContainer(%r, filter=%r)' % (self.content, self.filter)
+        return 'ConditionalContainer({0!r}, filter={1!r})'.format(self.content, self.filter)
 
     def reset(self):
         self.content.reset()

--- a/prompt_toolkit/layout/controls.py
+++ b/prompt_toolkit/layout/controls.py
@@ -226,7 +226,7 @@ class TokenListControl(UIControl):
         self._tokens = None
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.get_tokens)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.get_tokens)
 
     def _get_tokens_cached(self, cli):
         """
@@ -369,7 +369,7 @@ class FillControl(UIControl):
         self.character = character
 
     def __repr__(self):
-        return '%s(character=%r, token=%r)' % (
+        return '{0!s}(character={1!r}, token={2!r})'.format(
             self.__class__.__name__, self.character, self.token)
 
     def reset(self):

--- a/prompt_toolkit/layout/dimension.py
+++ b/prompt_toolkit/layout/dimension.py
@@ -63,7 +63,7 @@ class LayoutDimension(object):
         return cls(min=amount, max=amount, preferred=amount)
 
     def __repr__(self):
-        return 'LayoutDimension(min=%r, max=%r, preferred=%r, weight=%r)' % (
+        return 'LayoutDimension(min={0!r}, max={1!r}, preferred={2!r}, weight={3!r})'.format(
             self.min, self.max, self.preferred, self.weight)
 
     def __add__(self, other):

--- a/prompt_toolkit/layout/margins.py
+++ b/prompt_toolkit/layout/margins.py
@@ -70,7 +70,7 @@ class NumberredMargin(Margin):
 
     def get_width(self, cli, get_ui_content):
         line_count = get_ui_content().line_count
-        return max(3, len('%s' % line_count) + 1)
+        return max(3, len('{0!s}'.format(line_count)) + 1)
 
     def create_margin(self, cli, window_render_info, width, height):
         relative = self.relative(cli)
@@ -94,15 +94,15 @@ class NumberredMargin(Margin):
                     # Current line.
                     if relative:
                         # Left align current number in relative mode.
-                        result.append((token_current, '%i' % (lineno + 1)))
+                        result.append((token_current, '{0:d}'.format((lineno + 1))))
                     else:
-                        result.append((token_current, ('%i ' % (lineno + 1)).rjust(width)))
+                        result.append((token_current, ('{0:d} '.format((lineno + 1))).rjust(width)))
                 else:
                     # Other lines.
                     if relative:
                         lineno = abs(lineno - current_lineno) - 1
 
-                    result.append((token, ('%i ' % (lineno + 1)).rjust(width)))
+                    result.append((token, ('{0:d} '.format((lineno + 1))).rjust(width)))
 
             last_lineno = lineno
             result.append((Token, '\n'))
@@ -240,7 +240,7 @@ class PromptMargin(Margin):
             tokens.append((Token, '\n'))
             if show_numbers:
                 if y != last_y:
-                    tokens.append((Token.LineNumber, ('%i ' % (y + 1)).rjust(width)))
+                    tokens.append((Token.LineNumber, ('{0:d} '.format((y + 1))).rjust(width)))
             else:
                 tokens.extend(tokens2)
             last_y = y

--- a/prompt_toolkit/layout/menus.py
+++ b/prompt_toolkit/layout/menus.py
@@ -113,7 +113,7 @@ class CompletionsMenuControl(UIControl):
 
         text, tw = _trim_text(completion.display, width - 2)
         padding = ' ' * (width - 2 - tw)
-        return [(token, ' %s%s ' % (text, padding))]
+        return [(token, ' {0!s}{1!s} '.format(text, padding))]
 
     def _get_menu_item_meta_tokens(self, completion, is_current_completion, width):
         if is_current_completion:
@@ -123,7 +123,7 @@ class CompletionsMenuControl(UIControl):
 
         text, tw = _trim_text(completion.display_meta, width - 2)
         padding = ' ' * (width - 2 - tw)
-        return [(token, ' %s%s ' % (text, padding))]
+        return [(token, ' {0!s}{1!s} '.format(text, padding))]
 
     def mouse_handler(self, cli, mouse_event):
         """
@@ -372,7 +372,7 @@ class MultiColumnCompletionMenuControl(UIControl):
         text, tw = _trim_text(completion.display, width)
         padding = ' ' * (width - tw - 1)
 
-        return [(token, ' %s%s' % (text, padding))]
+        return [(token, ' {0!s}{1!s}'.format(text, padding))]
 
     def mouse_handler(self, cli, mouse_event):
         """
@@ -486,6 +486,6 @@ class _SelectedCompletionMetaControl(UIControl):
         state = cli.current_buffer.complete_state
 
         if state and state.current_completion and state.current_completion.display_meta:
-            return [(token, ' %s ' % state.current_completion.display_meta)]
+            return [(token, ' {0!s} '.format(state.current_completion.display_meta))]
 
         return []

--- a/prompt_toolkit/layout/processors.py
+++ b/prompt_toolkit/layout/processors.py
@@ -284,7 +284,7 @@ class BeforeInput(Processor):
         return cls(get_static_tokens)
 
     def __repr__(self):
-        return '%s(get_tokens=%r)' % (
+        return '{0!s}(get_tokens={1!r})'.format(
             self.__class__.__name__, self.get_tokens)
 
 
@@ -318,7 +318,7 @@ class AfterInput(Processor):
         return cls(get_static_tokens)
 
     def __repr__(self):
-        return '%s(get_tokens=%r)' % (
+        return '{0!s}(get_tokens={1!r})'.format(
             self.__class__.__name__, self.get_tokens)
 
 
@@ -518,5 +518,5 @@ class ConditionalProcessor(Processor):
             return False
 
     def __repr__(self):
-        return '%s(processor=%r, filter=%r)' % (
+        return '{0!s}(processor={1!r}, filter={2!r})'.format(
             self.__class__.__name__, self.processor, self.filter)

--- a/prompt_toolkit/layout/prompt.py
+++ b/prompt_toolkit/layout/prompt.py
@@ -87,7 +87,7 @@ def _get_isearch_tokens(cli):
         else:
             text = 'i-search'
 
-        return [(Token.Prompt.Search, '(%s)`' % text)]
+        return [(Token.Prompt.Search, '({0!s})`'.format(text))]
 
     def text():
         return [(Token.Prompt.Search.Text, cli.buffers[SEARCH_BUFFER].text)]

--- a/prompt_toolkit/layout/screen.py
+++ b/prompt_toolkit/layout/screen.py
@@ -84,7 +84,7 @@ class Char(object):
         return self.char != other.char or self.token != other.token
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self.char, self.token)
+        return '{0!s}({1!r}, {2!r})'.format(self.__class__.__name__, self.char, self.token)
 
 
 _CHAR_CACHE = FastDictCache(Char, size=1000 * 1000)
@@ -143,6 +143,6 @@ class WritePosition(object):
         self.extended_height = extended_height or height
 
     def __repr__(self):
-        return '%s(%r, %r, %r, %r, %r)' % (
+        return '{0!s}({1!r}, {2!r}, {3!r}, {4!r}, {5!r})'.format(
             self.__class__.__name__,
             self.xpos, self.ypos, self.width, self.height, self.extended_height)

--- a/prompt_toolkit/layout/toolbars.py
+++ b/prompt_toolkit/layout/toolbars.py
@@ -184,7 +184,7 @@ class ValidationToolbarControl(TokenListControl):
                     buffer.validation_error.cursor_position)
 
                 if show_position:
-                    text = '%s (line=%s column=%s)' % (
+                    text = '{0!s} (line={1!s} column={2!s})'.format(
                         buffer.validation_error.message, row + 1, column + 1)
                 else:
                     text = buffer.validation_error.message

--- a/prompt_toolkit/mouse_events.py
+++ b/prompt_toolkit/mouse_events.py
@@ -42,4 +42,4 @@ class MouseEvent(object):
         self.event_type = event_type
 
     def __repr__(self):
-        return 'MouseEvent(%r, %r)' % (self.position, self.event_type)
+        return 'MouseEvent({0!r}, {1!r})'.format(self.position, self.event_type)

--- a/prompt_toolkit/reactive.py
+++ b/prompt_toolkit/reactive.py
@@ -50,7 +50,7 @@ class _IntegerFromCallable(Integer):
         self.func = func
 
     def __repr__(self):
-        return 'Integer.from_callable(%r)' % self.func
+        return 'Integer.from_callable({0!r})'.format(self.func)
 
     def __int__(self):
         return int(self.func())

--- a/prompt_toolkit/search_state.py
+++ b/prompt_toolkit/search_state.py
@@ -20,7 +20,7 @@ class SearchState(object):
         self.ignore_case = ignore_case
 
     def __repr__(self):
-        return '%s(%r, direction=%r, ignore_case=%r)' % (
+        return '{0!s}({1!r}, direction={2!r}, ignore_case={3!r})'.format(
             self.__class__.__name__, self.text, self.direction, self.ignore_case)
 
     def __invert__(self):

--- a/prompt_toolkit/selection.py
+++ b/prompt_toolkit/selection.py
@@ -35,6 +35,6 @@ class SelectionState(object):
         self.type = type
 
     def __repr__(self):
-        return '%s(original_cursor_position=%r, type=%r)' % (
+        return '{0!s}(original_cursor_position={1!r}, type={2!r})'.format(
             self.__class__.__name__,
             self.original_cursor_position, self.type)

--- a/prompt_toolkit/styles/from_dict.py
+++ b/prompt_toolkit/styles/from_dict.py
@@ -35,7 +35,7 @@ def _colorformat(text):
     elif text == '':
         return text
 
-    raise ValueError('Wrong color format %r' % text)
+    raise ValueError('Wrong color format {0!r}'.format(text))
 
 
 def style_from_dict(style_dict, include_defaults=True):

--- a/prompt_toolkit/terminal/vt100_output.py
+++ b/prompt_toolkit/terminal/vt100_output.py
@@ -376,7 +376,7 @@ class Vt100_Output(Output):
         Set terminal title.
         """
         if self.term not in ('linux', 'eterm-color'):  # Not supported by the Linux console.
-            self.write_raw('\x1b]2;%s\x07' % title.replace('\x1b', '').replace('\x07', ''))
+            self.write_raw('\x1b]2;{0!s}\x07'.format(title.replace('\x1b', '').replace('\x07', '')))
 
     def clear_title(self):
         self.set_title('')
@@ -452,7 +452,7 @@ class Vt100_Output(Output):
 
     def cursor_goto(self, row=0, column=0):
         """ Move cursor position. """
-        self.write_raw('\x1b[%i;%iH' % (row, column))
+        self.write_raw('\x1b[{0:d};{1:d}H'.format(row, column))
 
     def cursor_up(self, amount):
         if amount == 0:
@@ -460,7 +460,7 @@ class Vt100_Output(Output):
         elif amount == 1:
             self.write_raw('\x1b[A')
         else:
-            self.write_raw('\x1b[%iA' % amount)
+            self.write_raw('\x1b[{0:d}A'.format(amount))
 
     def cursor_down(self, amount):
         if amount == 0:
@@ -470,7 +470,7 @@ class Vt100_Output(Output):
             #       scroll.
             self.write_raw('\x1b[B')
         else:
-            self.write_raw('\x1b[%iB' % amount)
+            self.write_raw('\x1b[{0:d}B'.format(amount))
 
     def cursor_forward(self, amount):
         if amount == 0:
@@ -478,7 +478,7 @@ class Vt100_Output(Output):
         elif amount == 1:
             self.write_raw('\x1b[C')
         else:
-            self.write_raw('\x1b[%iC' % amount)
+            self.write_raw('\x1b[{0:d}C'.format(amount))
 
     def cursor_backward(self, amount):
         if amount == 0:
@@ -486,7 +486,7 @@ class Vt100_Output(Output):
         elif amount == 1:
             self.write_raw('\b')  # '\x1b[D'
         else:
-            self.write_raw('\x1b[%iD' % amount)
+            self.write_raw('\x1b[{0:d}D'.format(amount))
 
     def hide_cursor(self):
         self.write_raw('\x1b[?25l')

--- a/prompt_toolkit/terminal/win32_output.py
+++ b/prompt_toolkit/terminal/win32_output.py
@@ -122,16 +122,16 @@ class Win32Output(Output):
         self.flush()
 
         if _DEBUG_RENDER_OUTPUT:
-            self.LOG.write(('%r' % func.__name__).encode('utf-8') + b'\n')
-            self.LOG.write(b'     ' + ', '.join(['%r' % i for i in a]).encode('utf-8') + b'\n')
-            self.LOG.write(b'     ' + ', '.join(['%r' % type(i) for i in a]).encode('utf-8') + b'\n')
+            self.LOG.write(('{0!r}'.format(func.__name__)).encode('utf-8') + b'\n')
+            self.LOG.write(b'     ' + ', '.join(['{0!r}'.format(i) for i in a]).encode('utf-8') + b'\n')
+            self.LOG.write(b'     ' + ', '.join(['{0!r}'.format(type(i)) for i in a]).encode('utf-8') + b'\n')
             self.LOG.flush()
 
         try:
             return func(*a, **kw)
         except ArgumentError as e:
             if _DEBUG_RENDER_OUTPUT:
-                self.LOG.write(('    Error in %r %r %s\n' % (func.__name__, e, e)).encode('utf-8'))
+                self.LOG.write(('    Error in {0!r} {1!r} {2!s}\n'.format(func.__name__, e, e)).encode('utf-8'))
 
     def get_win32_screen_buffer_info(self):
         """
@@ -258,7 +258,7 @@ class Win32Output(Output):
         data = ''.join(self._buffer)
 
         if _DEBUG_RENDER_OUTPUT:
-            self.LOG.write(('%r' % data).encode('utf-8') + b'\n')
+            self.LOG.write(('{0!r}'.format(data)).encode('utf-8') + b'\n')
             self.LOG.flush()
 
         # Print characters one by one. This appears to be the best soluton

--- a/prompt_toolkit/validation.py
+++ b/prompt_toolkit/validation.py
@@ -28,7 +28,7 @@ class ValidationError(Exception):
         self.message = message
 
     def __repr__(self):
-        return '%s(cursor_position=%r, message=%r)' % (
+        return '{0!s}(cursor_position={1!r}, message={2!r})'.format(
             self.__class__.__name__, self.cursor_position, self.message)
 
 

--- a/prompt_toolkit/win32_types.py
+++ b/prompt_toolkit/win32_types.py
@@ -21,7 +21,7 @@ class COORD(Structure):
     ]
 
     def __repr__(self):
-        return '%s(X=%r, Y=%r, type_x=%r, type_y=%r)' % (
+        return '{0!s}(X={1!r}, Y={2!r}, type_x={3!r}, type_y={4!r})'.format(
             self.__class__.__name__, self.X, self.Y, type(self.X), type(self.Y))
 
 
@@ -135,12 +135,12 @@ class CONSOLE_SCREEN_BUFFER_INFO(Structure):
     ]
 
     def __str__(self):
-        return '(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)' % (
+        return '({0:d},{1:d},{2:d},{3:d},{4:d},{5:d},{6:d},{7:d},{8:d},{9:d},{10:d})'.format(
             self.dwSize.Y, self.dwSize.X,
             self.dwCursorPosition.Y, self.dwCursorPosition.X,
             self.wAttributes,
             self.srWindow.Top, self.srWindow.Left, self.srWindow.Bottom, self.srWindow.Right,
-            self.dwMaximumWindowSize.Y, self.dwMaximumWindowSize.X,
+            self.dwMaximumWindowSize.Y, self.dwMaximumWindowSize.X
         )
 
 

--- a/tests/regular_languages_tests/__init__.py
+++ b/tests/regular_languages_tests/__init__.py
@@ -78,13 +78,13 @@ class GrammarTest(unittest.TestCase):
     def test_completer(self):
         class completer1(Completer):
             def get_completions(self, document, complete_event):
-                yield Completion('before-%s-after' % document.text, -len(document.text))
-                yield Completion('before-%s-after-B' % document.text, -len(document.text))
+                yield Completion('before-{0!s}-after'.format(document.text), -len(document.text))
+                yield Completion('before-{0!s}-after-B'.format(document.text), -len(document.text))
 
         class completer2(Completer):
             def get_completions(self, document, complete_event):
-                yield Completion('before2-%s-after2' % document.text, -len(document.text))
-                yield Completion('before2-%s-after2-B' % document.text, -len(document.text))
+                yield Completion('before2-{0!s}-after2'.format(document.text), -len(document.text))
+                yield Completion('before2-{0!s}-after2-B'.format(document.text), -len(document.text))
 
         # Create grammar.  "var1" + "whitespace" + "var2"
         g = compile(r'(?P<var1>[a-z]*) \s+ (?P<var2>[a-z]*)')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:python-prompt-toolkit?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:python-prompt-toolkit?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
